### PR TITLE
fix: file descriptors exhaustion by opening too much connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.22"
 paris = { version = "1.5.15", features = ["macros", "timestamps"] }
 reqwest = "0.12.12"
 scylla = { version = "0.15.1", features = ["chrono-04"] }
-tokio = "1.42.0"
+tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
 async-trait = "0.1.83"
 actix-web = "4.9.0"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -8,6 +8,7 @@ use jetstream_oxide::events::commit::{CommitData, CommitEvent};
 use jetstream_oxide::events::EventInfo;
 use std::fmt::Display;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 enum AppBskyEventRecord {
     Post,
@@ -39,14 +40,19 @@ impl CreateEventPayload {
     }
 }
 
-pub async fn events_handler(repository: &Arc<DatabaseRepository>, commit: CommitEvent) {
+pub async fn events_handler(
+    repository: &Arc<DatabaseRepository>,
+    commit: CommitEvent,
+    semaphore: Arc<Semaphore>,
+) {
     match commit {
         CommitEvent::Create {
             info: user_info,
             commit,
         } => {
             let payload = CreateEventPayload::new(user_info, commit);
-            create_event_handler(repository, payload).await;
+
+            create_event_handler(repository, payload, semaphore).await;
         }
         CommitEvent::Delete { .. } => {
             // delete_event_handler(repository, info, commit).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use scylla::transport::session::{CurrentDeserializationApi, GenericSession};
 use std::sync::Arc;
 use tokio::task::JoinSet;
 
-#[actix_web::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() {
     Logger::new();
     env_logger::init();


### PR DESCRIPTION
After letting the service running for a few seconds, it exhausted the connections due excessive thread spawning. To address that, I made two main changes:

1. Set a fixed number of worker threads, 10, using tokio parameters [1](https://docs.rs/tokio/1.43.0/tokio/attr.main.html#multi-threaded-runtime);
2. Implement a basic semaphore to limit the concurrent usage of create_event_handler to 100;

The number of worker threads and permits in the semaphores, is arbitrary and is what seems reasonable, at some point it will be nice to test different combinations to get an optimal setup.

 